### PR TITLE
添加 VC-LTL 的 Rust 语言支持

### DIFF
--- a/.github/workflows/Build&Test.yml
+++ b/.github/workflows/Build&Test.yml
@@ -105,6 +105,9 @@ jobs:
                   echo $releaseNotes | out-file "Nuget\VC-LTL-New.nuspec" -Append
                   echo $content.Remove(0, $releaseNotesIndex + $releaseNotesToken.Length) | out-file "Nuget\VC-LTL-New.nuspec" -NoNewline -Append
               }
+
+              # 替换 Cargo.toml 的版本号以为 crate 包生成做准备
+              (Get-Content -path "Rust\Cargo.toml.template" -Raw) -replace 'version = "$version$"','version = "$BuildVersion"' | Out-File -FilePath "Rust\Cargo.toml"
           }
 
     - name: 执行编译
@@ -223,11 +226,35 @@ jobs:
         tags: true
         draft: false
 
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        
     - name: 内容发布
       if: contains(github.ref, 'tags/')
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: cmd
       run: |
-         :: 把生成的nuget包发布到nuget中
-         nuget push VC-LTL.${{env.BuildVersion}}.nupkg -ApiKey ${{ secrets.NUGET_TOKEN }} -Source https://api.nuget.org/v3/index.json
+
+        set "Path=${{env.MSBuildBinPath}};%Path%"
+
+        :: 准备 Rust 打包所需要的内容
+        if "${{env.BuildVersion}}" NEQ "" (
+            msbuild Build.proj -t:PrepareToCompileRustLanguageSupport
+        )
+
+        :: 切换到 Rust 目录
+        pushd Rust
+        
+        :: 登录 Cargo
+        cargo login ${{ secrets.CARGO_TOKEN }}
+
+        :: 生成并发布 
+        cargo publish --allow-dirty
+
+        :: 切换回项目目录
+        popd
+
+        :: 把生成的nuget包发布到nuget中
+        nuget push VC-LTL.${{env.BuildVersion}}.nupkg -ApiKey ${{ secrets.NUGET_TOKEN }} -Source https://api.nuget.org/v3/index.json
 

--- a/Build.proj
+++ b/Build.proj
@@ -149,6 +149,21 @@
     <Exec Command="%22$(MSBuildThisFileDirectory)Tools\LibMaker.exe%22 RemoveAPISet %22%(RedistFiles.identity)%22 %22$(MSBuildThisFileDirectory)Tools\ApiSetMap.txt%22" WorkingDirectory="$(MSBuildThisFileDirectory)"/>
   </Target>
 
+  <!-- VC-LTL Rust crate 编译准备 -->
+  <Target Name="PrepareToCompileRustLanguageSupport">
+    <ItemGroup>
+      <RustTargetPlatform_x86 Include="$(SolutionDir)TargetPlatform\6.0.6000.0\lib\Win32\*ucrt.*;$(SolutionDir)TargetPlatform\6.0.6000.0\lib\Win32\*vcruntime.*;" />
+      <RustTargetPlatform_x64 Include="$(SolutionDir)TargetPlatform\6.0.6000.0\lib\x64\*ucrt.*;$(SolutionDir)TargetPlatform\6.0.6000.0\lib\x64\*vcruntime.*;" />
+      <RustTargetPlatform_arm64 Include="$(SolutionDir)TargetPlatform\10.0.10240.0\lib\ARM64\*ucrt.*;$(SolutionDir)TargetPlatform\10.0.10240.0\lib\ARM64\*vcruntime.*;" />
+      <RustTargetPlatform_Common Include="$(SolutionDir)Readme.md;$(SolutionDir)LICENSE;" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(RustTargetPlatform_x86)" DestinationFolder="$(SolutionDir)Rust\TargetPlatform\6.0.6000.0\lib\Win32" />
+    <Copy SourceFiles="@(RustTargetPlatform_x64)" DestinationFolder="$(SolutionDir)Rust\TargetPlatform\6.0.6000.0\lib\x64" />
+    <Copy SourceFiles="@(RustTargetPlatform_arm64)" DestinationFolder="$(SolutionDir)Rust\TargetPlatform\10.0.10240.0\lib\ARM64" />
+    <Copy SourceFiles="@(RustTargetPlatform_Common)" DestinationFolder="$(SolutionDir)Rust" />
+  </Target>
+
   <Target Name="Pack">
     <PropertyGroup>
       <ZipFileName Condition="'$(TagVersion)' == ''">VC-LTL-Binary.7z</ZipFileName>

--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,7 @@
 ![contributors](https://img.shields.io/github/contributors-anon/Chuyu-Team/VC-LTL5)
 ![release](https://img.shields.io/github/v/release/Chuyu-Team/VC-LTL5?include_prereleases)
 ![nuget](https://img.shields.io/nuget/vpre/VC-LTL)
+[![crates.io](https://img.shields.io/crates/v/vc-ltl.svg)](https://crates.io/crates/vc-ltl)
 [![Build&Test](https://github.com/Chuyu-Team/VC-LTL5/actions/workflows/Build&Test.yml/badge.svg)](https://github.com/Chuyu-Team/VC-LTL5/actions/workflows/Build&Test.yml)
 
 - [简体中文](Readme.osc.md)

--- a/Readme.osc.md
+++ b/Readme.osc.md
@@ -4,6 +4,7 @@
 ![contributors](https://img.shields.io/github/contributors-anon/Chuyu-Team/VC-LTL5)
 ![release](https://img.shields.io/github/v/release/Chuyu-Team/VC-LTL5?include_prereleases)
 ![nuget](https://img.shields.io/nuget/vpre/VC-LTL)
+[![crates.io](https://img.shields.io/crates/v/vc-ltl.svg)](https://crates.io/crates/vc-ltl)
 [![Build&Test](https://github.com/Chuyu-Team/VC-LTL5/actions/workflows/Build&Test.yml/badge.svg)](https://github.com/Chuyu-Team/VC-LTL5/actions/workflows/Build&Test.yml)
 
 - [English](Readme.md)

--- a/Rust/Cargo.toml.template
+++ b/Rust/Cargo.toml.template
@@ -1,0 +1,13 @@
+[package]
+edition = "2018"
+name = "vc-ltl"
+version = "$version$"
+authors = ["mingkuang <mingkuang@live.com>", "Kenji Mouri <Mouri_Naruto@Outlook.com>"]
+build = "build.rs"
+include = ["/src", "/TargetPlatform", "build.rs"]
+description = "Shared to msvcrt.dll or ucrtbase.dll and optimize the application file size."
+readme = "ReadMe.md"
+license-file = "LICENSE"
+repository = "https://github.com/Chuyu-Team/VC-LTL5"
+
+[dependencies]

--- a/Rust/build.rs
+++ b/Rust/build.rs
@@ -1,0 +1,137 @@
+/*
+ * PROJECT:   Rust language support for VC-LTL
+ * FILE:      build.rs
+ * PURPOSE:   Implementation for build script
+ *
+ * LICENSE:   The MIT License
+ *
+ * DEVELOPER: Mouri_Naruto (Mouri_Naruto AT Outlook.com)
+ */
+
+fn main()
+{
+    if !std::env::var("CARGO_CFG_WINDOWS").is_ok()
+    {
+        println!("cargo:warning=VC-LTL only supports Windows host. So the VC-LTL stage is skipped.");
+        return;
+    }
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect(
+        "CARGO_CFG_TARGET_OS should be set by cargo.");
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").expect(
+        "CARGO_CFG_TARGET_ENV should be set by cargo.");
+
+    if !target_os.contains("windows")
+    {
+        println!("cargo:warning=VC-LTL only supports Windows target. So the VC-LTL stage is skipped.");
+        return;
+    }
+
+    if !target_env.contains("msvc")
+    {
+        println!("cargo:warning=VC-LTL only supports MSVC toolchain. So the VC-LTL stage is skipped.");
+        return;
+    }
+
+    let package_root = std::env::var("CARGO_MANIFEST_DIR").expect(
+        "CARGO_MANIFEST_DIR should be set by cargo.");
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").expect(
+        "CARGO_CFG_TARGET_ARCH should be set by cargo.");
+
+    let target_platform;
+    let mut minimum_version = 6000;
+
+    if target_arch.contains("x86_64")
+    {
+        target_platform = "x64";
+        if minimum_version < 3790
+        {
+            minimum_version = 3790;
+        }
+    }
+    else if target_arch.contains("x86")
+    {
+        target_platform = "Win32";
+        if minimum_version < 2600
+        {
+            minimum_version = 2600;
+        }
+    }
+    else if target_arch.contains("arm")
+    {
+        target_platform = "ARM";
+        if minimum_version < 9200
+        {
+            minimum_version = 9200;
+        }
+    }
+    else if target_arch.contains("aarch64")
+    {
+        target_platform = "ARM64";
+        if minimum_version < 10240
+        {
+            minimum_version = 10240;
+        }
+    }
+    else
+    {
+        println!("cargo:warning=VC-LTL does not support {} platform. So the VC-LTL stage is skipped.", target_arch);
+        return;
+    }
+
+    let minimum_version_string;
+
+    if minimum_version >= 19041
+    {
+        minimum_version_string = "10.0.19041.0";
+    }
+    else if minimum_version >= 10240
+    {
+        minimum_version_string = "10.0.10240.0";
+    }
+    else if minimum_version >= 9200
+    {
+        minimum_version_string = "6.2.9200.0"
+    }
+    else if minimum_version >= 6000
+    {
+        minimum_version_string = "6.0.6000.0"
+    }
+    else if minimum_version >= 3790
+    {
+        minimum_version_string = "5.2.3790.0"
+    }
+    else
+    {
+        minimum_version_string = "5.1.2600.0"
+    }
+
+    let library_folder = &format!(
+        "{}/TargetPlatform/{}/lib/{}",
+        package_root,
+        minimum_version_string,
+        target_platform);
+
+    if !std::path::Path::new(library_folder).exists()
+    {
+        println!("cargo:warning=VC-LTL can't find lib files, please download the binary files from https://github.com/Chuyu-Team/VC-LTL/releases/latest. So the VC-LTL stage is skipped.");
+        return;
+    }
+
+    println!("cargo:warning=#######################################################################");
+    println!("cargo:warning=#                                                                     #");
+    println!("cargo:warning=#     *         *      * *             *        * * * * *  *          #");
+    println!("cargo:warning=#      *       *     *                 *            *      *          #");
+    println!("cargo:warning=#       *     *     *       * * * * *  *            *      *          #");
+    println!("cargo:warning=#        *   *       *                 *            *      *          #");
+    println!("cargo:warning=#          *           * *             * * * *      *      * * * *    #");
+    println!("cargo:warning=#                                                                     #");
+    println!("cargo:warning=#######################################################################");
+    println!("cargo:warning=VC-LTL Path : {}", package_root);
+    println!("cargo:warning=WindowsTargetPlatformMinVersion : {}", minimum_version_string);
+    println!("cargo:warning=Platform : {}", target_platform);
+
+    println!("cargo:rustc-link-search={}", library_folder);
+
+    return;
+}

--- a/Rust/src/lib.rs
+++ b/Rust/src/lib.rs
@@ -1,0 +1,9 @@
+/*
+ * PROJECT:   Rust language support for VC-LTL
+ * FILE:      lib.rs
+ * PURPOSE:   Implementation for VC-LTL information
+ *
+ * LICENSE:   The MIT License
+ *
+ * DEVELOPER: Mouri_Naruto (Mouri_Naruto AT Outlook.com)
+ */


### PR DESCRIPTION
本 PR 为 https://github.com/Chuyu-Team/VC-LTL5/pull/10 的 rebase 结果

经过多日的开发和测试，终于初步实现 VC-LTL 的 Rust 语言支持并实现自动上传到 crates.io

所需部署 Token 我已经设置完毕，鸭子可以在 Chuyu-Team 找到 CARGO_TOKEN

因为测试中途因为其中一个版本的 CI 脚本出现了 Bug，于是导致意外上传了 5.0.2 没有任何 tag 的版本，因为 Rust 只能把包屏蔽掉不能删除包，鸭子需要把 VC-LTL 的版本跳到 5.0.3，对此表示歉意

鉴于 crates.io 最大只能上传 10MB 的包，再加上 Rust 官方只提供了 x86 x64 arm64 的二进制 Windows MSVC 工具链，于是 Rust 版本只提供 6.0.6000 模式的 x86 和 x64 库还有 10.0.10240 模式的 arm64 库

注：由于 CI 脚本会对 Cargo.toml 的 version 部分内容自动替换为 tag 对应的版本号，于是该部分修改时需要额外注意

毛利