### PR TITLE
Fix multi-config CMake build

### DIFF
--- a/config/config.cmake
+++ b/config/config.cmake
@@ -17,13 +17,6 @@ if(NOT CleanImport)
 endif()
 
 if(${SupportLTL} STREQUAL "true")
-	if(NOT CMAKE_BUILD_TYPE)
-		message(WARNING "VC-LTL not load, because CMAKE_BUILD_TYPE is not defined!!!")
-		set(SupportLTL "false")
-	endif()
-endif()
-
-if(${SupportLTL} STREQUAL "true")
 	if(NOT CMAKE_SYSTEM_NAME)
 		message(WARNING "VC-LTL not load, because CMAKE_SYSTEM_NAME is not defined!!!")
 		set(SupportLTL "false")


### PR DESCRIPTION
CMake支持multi-config构建，然而multi-config不能设置CMAKE_BUILD_TYPE，但这会导致不能使用VC-LTL。看了看整个脚本，也没有需要使用CMAKE_BUILD_TYPE的地方，因此直接去掉此处判断，从而使multi-config也能使用VC-LTL。