### PR TITLE
Update license information for third party libraries.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -204,4 +204,4 @@ Is the file size smaller? If you fail to compile, please refer to [4. FAQ](#4-fa
 
 ## Excursus - Third Party Licenses
 * [Visual Studio](https://visualstudio.microsoft.com/license-terms/)
-* [Windows Software Developer Kit](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
+* [Microsoft.Windows.SDK.CRTSource](https://www.nuget.org/packages/Microsoft.Windows.SDK.CRTSource/10.0.22621.3/License)

--- a/Readme.osc.md
+++ b/Readme.osc.md
@@ -196,4 +196,4 @@ nmake /f Test.mak
 
 ## 附：第三方依赖项许可
 * [Visual Studio](https://visualstudio.microsoft.com/license-terms/)
-* [Windows Software Developer Kit](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
+* [Microsoft.Windows.SDK.CRTSource](https://www.nuget.org/packages/Microsoft.Windows.SDK.CRTSource/10.0.22621.3/License)


### PR DESCRIPTION
Due to Microsoft released [Universal C Runtime's source code via NuGet](https://www.nuget.org/packages/Microsoft.Windows.SDK.CRTSource) and licensed under the MIT License.

Everyone knows VC-LTL do some modifications based on that.

So, I think it's time to update the license information for VC-LTL 5.x to improve the clarity of the license for VC-LTL.

Kenji Mouri